### PR TITLE
fix(bloom): BloomBitsPerKey does not depend on number of keys

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -446,7 +446,7 @@ func (b *Builder) Done() buildData {
 
 	var f y.Filter
 	if b.opts.BloomFalsePositive > 0 {
-		bits := y.BloomBitsPerKey(len(b.keyHashes), b.opts.BloomFalsePositive)
+		bits := y.BloomBitsPerKey(b.opts.BloomFalsePositive)
 		f = y.NewFilter(b.keyHashes, bits)
 	}
 	index, dataSize := b.buildIndex(f)

--- a/y/bloom.go
+++ b/y/bloom.go
@@ -49,6 +49,12 @@ func NewFilter(keys []uint32, bitsPerKey int) Filter {
 // BloomBitsPerKey returns the bits per key required by bloomfilter based on
 // the false positive rate.
 func BloomBitsPerKey(fp float64) int {
+	if fp <= 0 {
+		return 75
+	}
+	if fp >= 1 {
+		return 1
+	}
 	return int(math.Ceil(-1.44 * math.Log2(fp)))
 }
 

--- a/y/bloom.go
+++ b/y/bloom.go
@@ -48,10 +48,8 @@ func NewFilter(keys []uint32, bitsPerKey int) Filter {
 
 // BloomBitsPerKey returns the bits per key required by bloomfilter based on
 // the false positive rate.
-func BloomBitsPerKey(numEntries int, fp float64) int {
-	size := -1 * float64(numEntries) * math.Log(fp) / math.Pow(float64(0.69314718056), 2)
-	locs := math.Ceil(float64(0.69314718056) * size / float64(numEntries))
-	return int(locs)
+func BloomBitsPerKey(fp float64) int {
+	return int(math.Ceil(-1.44 * math.Log2(fp)))
 }
 
 func appendFilter(buf []byte, keys []uint32, bitsPerKey int) []byte {

--- a/y/bloom_test.go
+++ b/y/bloom_test.go
@@ -5,6 +5,7 @@
 package y
 
 import (
+	"math"
 	"testing"
 )
 
@@ -142,6 +143,28 @@ func TestHash(t *testing.T) {
 	for _, tc := range testCases {
 		if got := Hash([]byte(tc.s)); got != tc.want {
 			t.Errorf("s=%q: got 0x%08x, want 0x%08x", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestBloomBitsPerKey(t *testing.T) {
+	testCases := []struct {
+		fp   float64
+		want int
+	}{
+		// epsilon (minimum possible float)
+		{math.Nextafter(1, 2) - 1, 75},
+		{0, 75},
+		{0.1, 5},
+		{0.01, 10},
+		{0.001, 15},
+		{0.999, 1},
+		{1, 1},
+		{math.MaxFloat64, 1},
+	}
+	for _, tc := range testCases {
+		if got := BloomBitsPerKey(tc.fp); got != tc.want {
+			t.Errorf("fp=%f: got %d, want %d", tc.fp, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
During the bits per key (m/n) calculation we first multiply the result by `numEntries` to get the size of the bloom filter (m), and then divide by `numEntries` to get the m/n.  Also for some reason, as was mentioned in #1763, current implementation underestimates the result by 30% because of erroneous multiplication by `Ln2`.

Wikipedia suggests that bits per key calculation can be simplified to:
<img src="https://render.githubusercontent.com/render/math?math=\frac{m}{n}=-\frac{\log_2\varepsilon}{\ln 2}\approx-1.44\log_2\varepsilon">

While here also fix edgecases for very small and large ε to protect against misuse and added tests.

This is a copy of: dgraph-io/badger#1773

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/badger/4)
<!-- Reviewable:end -->
