### PR TITLE
chore(bloom): added Hash benchmark

### DIFF
--- a/y/bloom_test.go
+++ b/y/bloom_test.go
@@ -5,7 +5,9 @@
 package y
 
 import (
+	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 )
 
@@ -122,6 +124,23 @@ loop:
 
 	if nMediocreFilters > nGoodFilters/5 {
 		t.Errorf("%d mediocre filters but only %d good filters", nMediocreFilters, nGoodFilters)
+	}
+}
+
+func BenchmarkHash(b *testing.B) {
+	for _, sz := range []int64{1, 3, 4, 7, 8, 16, 32, 256, 1024, 4096} {
+		d := make([]byte, sz)
+		_, err := rand.Read(d)
+		if err != nil {
+			b.Errorf("failed to read %d random bytes %s", sz, err)
+		}
+		b.Run(fmt.Sprintf("hasher-%d", sz), func(b *testing.B) {
+			b.SetBytes(sz)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = Hash(d)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This adds an ability to replace hashing algorithms in the future and measure the impact.

For example, [xxh3 w/ AVX2](https://github.com/zeebo/xxh3) is capable of 20.1 ns/op (12.0 GB/s) on medium sized keys, meanwhile the current perf is:
```
name                time/op
Hash/hasher-1-8       2.40ns ± 3%
Hash/hasher-3-8       3.31ns ± 2%
Hash/hasher-4-8       3.55ns ± 5%
Hash/hasher-7-8       4.79ns ± 2%
Hash/hasher-8-8       4.80ns ± 1%
Hash/hasher-16-8      7.17ns ± 3%
Hash/hasher-32-8      11.9ns ± 2%
Hash/hasher-256-8      102ns ± 5%
Hash/hasher-1024-8     427ns ± 3%
Hash/hasher-4096-8    1.68µs ± 1%

name                speed
Hash/hasher-1-8      417MB/s ± 3%
Hash/hasher-3-8      907MB/s ± 2%
Hash/hasher-4-8     1.13GB/s ± 5%
Hash/hasher-7-8     1.46GB/s ± 2%
Hash/hasher-8-8     1.67GB/s ± 1%
Hash/hasher-16-8    2.23GB/s ± 3%
Hash/hasher-32-8    2.70GB/s ± 2%
Hash/hasher-256-8   2.52GB/s ± 5%
Hash/hasher-1024-8  2.40GB/s ± 4%
Hash/hasher-4096-8  2.44GB/s ± 1%
```

This is a slightly improved version of dgraph-io/badger#1774

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/badger/5)
<!-- Reviewable:end -->
