### PR TITLE
feat(db): Allow maxValueSize as option

### DIFF
--- a/options.go
+++ b/options.go
@@ -67,6 +67,7 @@ type Options struct {
 	LevelSizeMultiplier int
 	TableSizeMultiplier int
 	MaxLevels           int
+	MaxValueSize        int64
 
 	VLogPercentile float64
 	ValueThreshold int64
@@ -185,6 +186,7 @@ func DefaultOptions(path string) Options {
 
 		VLogPercentile: 0.0,
 		ValueThreshold: maxValueThreshold,
+		MaxValueSize:   maxValueSize,
 
 		Logger:                        defaultLogger(INFO),
 		EncryptionKey:                 []byte{},
@@ -216,6 +218,7 @@ func buildTableOptions(db *DB) table.Options {
 
 const (
 	maxValueThreshold = (1 << 20) // 1 MB
+	maxValueSize      = (1 << 20) // 1 MB
 )
 
 // LSMOnlyOptions follows from DefaultOptions, but sets a higher ValueThreshold
@@ -495,6 +498,16 @@ func (opt Options) WithLevelSizeMultiplier(val int) Options {
 // The default value of MaxLevels is 7.
 func (opt Options) WithMaxLevels(val int) Options {
 	opt.MaxLevels = val
+	return opt
+}
+
+// WithMaxValueSize returns a new Options value with maxValueSize set to the given value.
+//
+// MaxValueSize sets the allowed size of values stored in badger.
+//
+// The default value of MaxValueSize is 1 MB.
+func (opt Options) WithMaxValueSize(val int64) Options {
+	opt.MaxValueSize = val
 	return opt
 }
 

--- a/txn.go
+++ b/txn.go
@@ -359,7 +359,6 @@ func exceedsSize(prefix string, max int64, key []byte) error {
 }
 
 const maxKeySize = 65000
-const maxValSize = 1 << 20
 
 func ValidEntry(db *DB, key, val []byte) error {
 	switch {
@@ -372,8 +371,8 @@ func ValidEntry(db *DB, key, val []byte) error {
 		// keep things safe and allow badger move prefix and a timestamp suffix, let's
 		// cut it down to 65000, instead of using 65536.
 		return exceedsSize("Key", maxKeySize, key)
-	case int64(len(val)) > maxValSize:
-		return exceedsSize("Value", maxValSize, val)
+	case int64(len(val)) > db.opt.MaxValueSize:
+		return exceedsSize("Value", db.opt.MaxValueSize, val)
 	}
 	if err := db.isBanned(key); err != nil {
 		return err


### PR DESCRIPTION
The maximum allowed value size was hardcoded to 1mb.
To allow storing bigger values I added the option MaxValueSize that can be set on badger initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/badger/8)
<!-- Reviewable:end -->
