### PR TITLE
feat: Improve bitmap, compaction efficiency. Add Lifetime stats.

### DIFF
--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -113,7 +113,7 @@ func handleInfo(cmd *cobra.Command, args []string) error {
 		if err := printInfo(sstDir); err != nil {
 			return y.Wrap(err, "failed to print information in MANIFEST file")
 		}
-		return
+		return nil
 	}
 
 	// Open DB

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -35,6 +35,7 @@ import (
 	"github.com/outcaste-io/badger/v4/options"
 	"github.com/outcaste-io/badger/v4/table"
 	"github.com/outcaste-io/badger/v4/y"
+	"github.com/outcaste-io/sroar"
 	"github.com/spf13/cobra"
 )
 
@@ -242,7 +243,12 @@ func printKey(item *badger.Item, showValue bool) error {
 			return y.Wrapf(err,
 				"failed to copy value of the key: %x(%d)", item.Key(), item.Version())
 		}
-		fmt.Fprintf(&buf, "\n\tvalue: %v", val)
+		if item.IsBitmap() {
+			bm := sroar.FromBuffer(val)
+			fmt.Fprintf(&buf, "\n\t bitmap: %s\n", bm.String())
+		} else {
+			fmt.Fprintf(&buf, "\n\tvalue: %v", val)
+		}
 	}
 	fmt.Println(buf.String())
 	return nil

--- a/badger/cmd/info.go
+++ b/badger/cmd/info.go
@@ -246,6 +246,8 @@ func printKey(item *badger.Item, showValue bool) error {
 		if item.IsBitmap() {
 			bm := sroar.FromBuffer(val)
 			fmt.Fprintf(&buf, "\n\t bitmap: %s\n", bm.String())
+			bm.Cleanup()
+			fmt.Fprintf(&buf, "\n\t after cleanup bitmap: %s\n", bm.String())
 		} else {
 			fmt.Fprintf(&buf, "\n\tvalue: %v", val)
 		}

--- a/db.go
+++ b/db.go
@@ -540,6 +540,9 @@ func (db *DB) close() (err error) {
 	if registryErr := db.registry.Close(); err == nil {
 		err = y.Wrap(registryErr, "DB.Close")
 	}
+	if lfErr := db.lf.Close(); err == nil {
+		err = y.Wrap(lfErr, "DB.Close")
+	}
 
 	// Fsync directories to ensure that lock file, and any other removed files whose directory
 	// we haven't specifically fsynced, are guaranteed to have their directory entry removal

--- a/db.go
+++ b/db.go
@@ -121,6 +121,8 @@ type DB struct {
 	blockCache *ristretto.Cache
 	indexCache *ristretto.Cache
 	allocPool  *z.AllocatorPool
+
+	lf *LifetimeStats
 }
 
 func checkAndSetOptions(opt *Options) error {
@@ -204,6 +206,7 @@ func Open(opt Options) (*DB, error) {
 		pub:              newPublisher(),
 		allocPool:        z.NewAllocatorPool(8),
 		bannedNamespaces: &lockedKeys{keys: make(map[uint64]struct{})},
+		lf:               InitLifetimeStats(filepath.Join(opt.Dir, "STATS")),
 	}
 	// Cleanup all the goroutines started by badger in case of an error.
 	defer func() {
@@ -663,6 +666,9 @@ var errNoRoom = errors.New("No room for write")
 
 type isLocked struct{}
 
+const idxBytesByUser = 129
+const idxBytesWritten = 130
+
 func (db *DB) handoverSkiplist(r *handoverRequest, _ isLocked) error {
 	sl, callback := r.skl, r.callback
 	req := &request{
@@ -672,6 +678,7 @@ func (db *DB) handoverSkiplist(r *handoverRequest, _ isLocked) error {
 
 	select {
 	case db.flushChan <- flushTask{sl: sl, cb: callback}:
+		db.lf.UpdateAt(idxBytesByUser, uint64(sl.MemSize()))
 		db.imm = append(db.imm, sl)
 		db.pub.sendUpdates(reqs)
 		return nil
@@ -927,6 +934,10 @@ func (db *DB) Tables() []TableInfo {
 	return db.lc.getTableInfo()
 }
 
+func (db *DB) LifetimeStats() map[int]uint64 {
+	return db.lf.Stats()
+}
+
 // Levels gets the LevelInfo.
 func (db *DB) Levels() []LevelInfo {
 	return db.lc.getLevelInfo()
@@ -1110,7 +1121,6 @@ func (db *DB) startMemoryFlush() {
 // stopped. Ideally, no writes are going on during Flatten. Otherwise, it would create competition
 // between flattening the tree and new tables being created at level zero.
 func (db *DB) Flatten(workers int) error {
-
 	db.stopCompactions()
 	defer db.startCompactions()
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/klauspost/compress v1.14.3
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/outcaste-io/ristretto v0.1.1-0.20220404170646-118eb5c81eac
-	github.com/outcaste-io/sroar v0.0.0-20220425202201-32ae257f7410 // indirect
+	github.com/outcaste-io/sroar v0.0.0-20221114214615-697d5538e564 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/outcaste-io/ristretto v0.1.1-0.20220404170646-118eb5c81eac h1:h2Sky+P
 github.com/outcaste-io/ristretto v0.1.1-0.20220404170646-118eb5c81eac/go.mod h1:LWEAKsXjquNJfHEtD/qDRdAQa5JV+F2gNMfIOZSEkuk=
 github.com/outcaste-io/sroar v0.0.0-20220425202201-32ae257f7410 h1:Hvk+ccd8cG2n2kxAvQ19oXqWYJ3buUAR3g5OXpeBBAE=
 github.com/outcaste-io/sroar v0.0.0-20220425202201-32ae257f7410/go.mod h1:qi6NCnRugS99q0RMa0E8JU5wAUePskKM1xmHwArCwew=
+github.com/outcaste-io/sroar v0.0.0-20221114214615-697d5538e564 h1:KfOq9+1GGXbFH+5zIELRxYVL80ofFGXXKZojjAKMfnU=
+github.com/outcaste-io/sroar v0.0.0-20221114214615-697d5538e564/go.mod h1:qi6NCnRugS99q0RMa0E8JU5wAUePskKM1xmHwArCwew=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/iterator.go
+++ b/iterator.go
@@ -140,6 +140,10 @@ func (item *Item) IsDeletedOrExpired() bool {
 	return isDeletedOrExpired(item.meta)
 }
 
+func (item *Item) IsBitmap() bool {
+	return item.meta&y.BitRoar > 0
+}
+
 // DiscardEarlierVersions returns whether the item was created with the
 // option to discard earlier versions of a key when multiple are available.
 func (item *Item) DiscardEarlierVersions() bool {

--- a/levels.go
+++ b/levels.go
@@ -1399,7 +1399,6 @@ func (s *levelsController) runCompactDef(id, l int, cd compactDef) (err error) {
 
 	// Table should never be moved directly between levels, always be rewritten to allow discarding
 	// invalid versions.
-
 	newTables, decr, err := s.compactBuildTables(l, cd)
 	if err != nil {
 		return err
@@ -1410,6 +1409,13 @@ func (s *levelsController) runCompactDef(id, l int, cd compactDef) (err error) {
 			err = decErr
 		}
 	}()
+
+	var written uint64
+	for _, t := range newTables {
+		written += uint64(t.UncompressedSize())
+	}
+	s.kv.lf.UpdateAt(idxBytesWritten, written)
+
 	changeSet := buildChangeSet(&cd, newTables)
 
 	// We write to the manifest _before_ we delete files (and after we created files)

--- a/lifetime.go
+++ b/lifetime.go
@@ -35,7 +35,7 @@ func InitLifetimeStats(path string) *LifetimeStats {
 	y.Check(err)
 
 	lf := &LifetimeStats{mf: mf}
-	lf.UpdateAt(idxOpen, 1)
+	lf.updateAt(idxOpen, 1)
 	return lf
 }
 
@@ -73,8 +73,11 @@ func (lf *LifetimeStats) UpdateAt(idx int, delta uint64) {
 }
 
 func (lf *LifetimeStats) Close() error {
-	lf.UpdateAt(idxClose, 1)
-	return lf.mf.Close(0)
+	lf.Lock()
+	defer lf.Unlock()
+
+	lf.updateAt(idxClose, 1)
+	return lf.mf.Close(-1)
 }
 
 func (lf *LifetimeStats) Stats() map[int]uint64 {

--- a/lifetime.go
+++ b/lifetime.go
@@ -24,7 +24,7 @@ var (
 )
 
 func InitLifetimeStats(path string) *LifetimeStats {
-	mf, err := z.OpenMmapFile(path, os.O_RDWR, maxSz)
+	mf, err := z.OpenMmapFile(path, os.O_RDWR|os.O_CREATE, maxSz)
 	if err == z.NewFile {
 		for i := range mf.Data {
 			mf.Data[i] = 0x0

--- a/lifetime.go
+++ b/lifetime.go
@@ -1,0 +1,92 @@
+package badger
+
+import (
+	"encoding/binary"
+	"os"
+	"sync"
+
+	"github.com/outcaste-io/badger/v4/y"
+	"github.com/outcaste-io/ristretto/z"
+)
+
+type LifetimeStats struct {
+	sync.RWMutex
+	mf *z.MmapFile
+}
+
+var (
+	maxSz            int = 1 << 20
+	idxVersion       int = 0
+	idxOpen          int = 1
+	idxClose         int = 2
+	idxNumWrites     int = 3
+	idxReservedBelow int = 128
+)
+
+func InitLifetimeStats(path string) *LifetimeStats {
+	mf, err := z.OpenMmapFile(path, os.O_RDWR, maxSz)
+	if err == z.NewFile {
+		for i := range mf.Data {
+			mf.Data[i] = 0x0
+		}
+		y.Check(mf.Sync())
+		err = nil
+	}
+	y.Check(err)
+
+	lf := &LifetimeStats{mf: mf}
+	lf.UpdateAt(idxOpen, 1)
+	return lf
+}
+
+func getOffset(idx int) int {
+	off := idx * 8
+	y.AssertTrue(off < maxSz)
+	return off
+}
+
+func (lf *LifetimeStats) readAt(idx int) uint64 {
+	offset := getOffset(idx)
+	return binary.BigEndian.Uint64(lf.mf.Data[offset : offset+8])
+}
+func (lf *LifetimeStats) updateAt(idx int, delta uint64) {
+	val := lf.readAt(idx)
+	val += delta
+
+	off := getOffset(idx)
+	binary.BigEndian.PutUint64(lf.mf.Data[off:off+8], val)
+}
+func (lf *LifetimeStats) ReadAt(idx int) uint64 {
+	lf.RLock()
+	val := lf.readAt(idx)
+	lf.RUnlock()
+	return val
+}
+
+func (lf *LifetimeStats) UpdateAt(idx int, delta uint64) {
+	lf.Lock()
+	defer lf.Unlock()
+
+	y.AssertTrue(idx > idxReservedBelow)
+	lf.updateAt(idx, delta)
+	lf.updateAt(idxNumWrites, 1)
+}
+
+func (lf *LifetimeStats) Close() error {
+	lf.UpdateAt(idxClose, 1)
+	return lf.mf.Close(0)
+}
+
+func (lf *LifetimeStats) Stats() map[int]uint64 {
+	res := make(map[int]uint64)
+
+	lf.RLock()
+	for i := 0; i < (1<<20)/8; i++ {
+		if val := lf.readAt(i); val > 0 {
+			res[i] = val
+		}
+	}
+	lf.RUnlock()
+
+	return res
+}

--- a/options.go
+++ b/options.go
@@ -127,8 +127,8 @@ func DefaultOptions(path string) Options {
 		Dir: path,
 
 		MemTableSize:        64 << 20,
-		BaseTableSize:       2 << 20,
-		BaseLevelSize:       10 << 20,
+		BaseTableSize:       8 << 20,
+		BaseLevelSize:       256 << 20,
 		TableSizeMultiplier: 2,
 		LevelSizeMultiplier: 10,
 		MaxLevels:           7,

--- a/txn.go
+++ b/txn.go
@@ -170,6 +170,9 @@ func (db *DB) GetBitmap(key []byte) (*sroar.Bitmap, error) {
 
 		for itr.Rewind(); itr.Valid(); itr.Next() {
 			item := itr.Item()
+			if item.meta&y.BitRoar == 0 {
+				continue
+			}
 			if err := item.Value(func(val []byte) error {
 				if bm == nil {
 					if len(val) > 0 {


### PR DESCRIPTION
- Only create a bitmap if the space used per uint64 is less than 8.0. Otherwise, directly store the key.
- Increase the base level size to 256 MiB, and file size to 8 MiB. This helps reduce the write amp from 7.2 to 6.5 on my bitmap run.
- Add a new LifetimeStats library, which can track the usage of Badger over its lifetime. Useful for determining write amplification.
 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/outcaste-io/badger/15)
<!-- Reviewable:end -->
